### PR TITLE
feat: add custom CSS properties from Params

### DIFF
--- a/layouts/_partials/head/libsass-hash.html
+++ b/layouts/_partials/head/libsass-hash.html
@@ -1,0 +1,13 @@
+{{- $css := "" -}}
+{{- if eq (hugo.Environment) "development" -}}
+  {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
+  {{ $css = resources.Get . | toCSS $options | resources.Fingerprint "sha512" -}}
+{{ else -}}
+  {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
+  {{/*  {{ $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | resources.Fingerprint "sha512" -}}  */}}
+  {{ $css = resources.Get . | toCSS $options | resources.Minify | resources.Fingerprint "sha512" -}}
+{{ end -}}
+{{- return (dict
+  "libsassCSS" $css
+  "hashes" (slice $css.Data.Integrity)
+) -}}

--- a/layouts/_partials/head/libsass.html
+++ b/layouts/_partials/head/libsass.html
@@ -1,9 +1,2 @@
-{{ $css := "" }}
-{{ if eq (hugo.Environment) "development" -}}
-  {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
-  {{ $css = resources.Get . | toCSS $options | resources.Fingerprint "sha512" -}}
-{{ else -}}
-  {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
-  {{ $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") |  resources.Fingerprint "sha512" | resources.PostProcess -}}
-{{ end -}}
-<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+{{ $cssDict := partial "head/libsass-hash.html" . }}
+<link rel="stylesheet" href="{{ $cssDict.libsassCSS.RelPermalink }}" integrity="{{ $cssDict.libsassCSS.Data.Integrity }}" crossorigin="anonymous">

--- a/layouts/_partials/head/stylesheet-hashes.html
+++ b/layouts/_partials/head/stylesheet-hashes.html
@@ -1,0 +1,31 @@
+{{- $cssVars := dict }}
+{{- if reflect.IsMap site.Params.cssVars }}
+  {{- $cssVars = merge $cssVars site.Params.cssVars }}
+{{- end }}
+{{- if reflect.IsMap page.Params.cssVars }}
+  {{ warnf "%s" page.Params.cssVars }}
+  {{- $cssVars = merge $cssVars page.Params.cssVars }}
+{{- end }}
+{{- $cssPropertiesVal := "" }}
+{{- $cssStyleHashes := slice }}
+{{- if gt (len $cssVars) 0 }}
+  {{- $cssProperties := slice }}
+  {{- $cssPropertiesVal = ":root {" -}}
+  {{- range $k, $v := $cssVars }}
+    {{- $cssProperties = $cssProperties | append (slice (printf " --%s: %s" $k $v)) }}
+  {{- end }}
+  {{- $cssPropertiesVal = add $cssPropertiesVal (delimit $cssProperties ";\n") "}" }}
+{{- end }}
+{{- $noscriptStyle := "img.lazyload { display:none; }" }}
+{{- $cssPropertiesCSS := resources.FromString "css/cssProperties.css" $cssPropertiesVal }}
+{{- $cssPropertiesCSS = $cssPropertiesCSS | resources.Minify | resources.Fingerprint "sha512" }}
+{{- $cssStyleHashes = $cssStyleHashes | append (slice $cssPropertiesCSS.Data.Integrity) }}
+{{- $cssNoscriptCSS := resources.FromString "css/Noscript.css" $noscriptStyle }}
+{{- $cssNoscriptCSS = $cssNoscriptCSS | resources.Minify | resources.Fingerprint "sha512" }}
+{{- $cssStyleHashes = $cssStyleHashes | append (slice $cssNoscriptCSS.Data.Integrity) }}
+{{- return (dict
+  "cssPropertiesCSS" $cssPropertiesCSS
+  "cssNoscriptCSS" $cssNoscriptCSS
+  "hashes" $cssStyleHashes
+) }}
+{{- /* */ -}}

--- a/layouts/_partials/head/stylesheet.html
+++ b/layouts/_partials/head/stylesheet.html
@@ -1,2 +1,16 @@
 {{ partial "head/libsass" "scss/app.scss"}}
+{{- $cssVars := dict }}
+{{- if reflect.IsMap site.Params.cssVars }}
+  {{- $cssVars = merge $cssVars site.Params.cssVars }}
+{{- end }}
+{{- if reflect.IsMap page.Params.cssVars }}
+  {{ warnf "%s" page.Params.cssVars }}
+  {{- $cssVars = merge $cssVars page.Params.cssVars }}
+{{- end }}
+{{- if gt (len $cssVars) 0 }}
+<style>:root {
+  {{- range $k, $v := $cssVars }} --{{- $k -}}:{{- $v | safeCSS -}};{{- end }}
+}
+</style>
+{{- end }}
 <noscript><style>img.lazyload { display: none; }</style></noscript>

--- a/layouts/_partials/head/stylesheet.html
+++ b/layouts/_partials/head/stylesheet.html
@@ -1,16 +1,8 @@
-{{ partial "head/libsass" "scss/app.scss"}}
-{{- $cssVars := dict }}
-{{- if reflect.IsMap site.Params.cssVars }}
-  {{- $cssVars = merge $cssVars site.Params.cssVars }}
+{{- partial "head/libsass" "scss/app.scss"}}
+{{- $styleDict := partial "head/stylesheet-hashes.html" . }}
+{{- if $styleDict.cssPropertiesCSS }}
+<style>{{- $styleDict.cssPropertiesCSS.Content | safeCSS -}}</style>
 {{- end }}
-{{- if reflect.IsMap page.Params.cssVars }}
-  {{ warnf "%s" page.Params.cssVars }}
-  {{- $cssVars = merge $cssVars page.Params.cssVars }}
+{{- if $styleDict.cssNoscriptCSS }}
+<noscript><style>{{- $styleDict.cssNoscriptCSS.Content | safeCSS -}}</style></noscript>
 {{- end }}
-{{- if gt (len $cssVars) 0 }}
-<style>:root {
-  {{- range $k, $v := $cssVars }} --{{- $k -}}:{{- $v | safeCSS -}};{{- end }}
-}
-</style>
-{{- end }}
-<noscript><style>img.lazyload { display: none; }</style></noscript>


### PR DESCRIPTION
## Summary

Adds a `<style>` element to `<head>` which contains custom CSS properties defined in the site or page Params parameter cssVars, if any are defined.

Since we currently only have one variable using this functionality we do not do a full postCSS treatment on this
style.

## Basic example

In `params.toml`

```toml
[cssVars]
   'markdown-svg' = '#fff'
```

would result in (in `<head>`):

```html
<style>:root { --markdown-svg:#fff; }</style>
```

which with an upcoming PR for <https://github.com/thulite/image> would set the background colour for a Markdown rendered SVG image to white (#fff).

## Motivation

Motivated by https://github.com/thuliteio/images/pull/36 which otherwise has a hard-coded background colour value for Markdown SVG files. This allows the designer to customize that background colour at a site or page level.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [ ] Supports both light and dark mode (if relevant) -- It allows customization but not per-mode; that would probably be overkill an difficult given the root cause issue this solves.
- [x] Passes `npm run test` (if relevant) (not relevant)
