### PR TITLE
Generate server headers especially Content-Security-Policy

### DIFF
--- a/data/serverHeaders/dynamic/Content-Security-Policy.toml
+++ b/data/serverHeaders/dynamic/Content-Security-Policy.toml
@@ -1,0 +1,28 @@
+"delimiter" = "; "
+"subDelimiter" = " "
+
+[subFields]
+"default-src" = "'self'"
+"manifest-src" = "'self'"
+
+"connect-src" = [
+    "'self'",
+    "##VAR_analytics##"
+]
+
+"font-src" = ""
+
+"img-src" = [
+  "'self'",
+  "data:"
+]
+
+"script-src" = [
+  "'self'",
+  "##VAR_analytics##",
+  "'sha256-aWZ3y/RxbBYKHXH0z8+8ljrHG1mSBvyzSfxSMjBSaXk='"
+]
+"style-src" = [
+  "'self'",
+  "'##VAR_styleHashes##'"
+]

--- a/data/serverHeaders/dynamic/Content-Security-Policy.toml
+++ b/data/serverHeaders/dynamic/Content-Security-Policy.toml
@@ -20,8 +20,9 @@
 "script-src" = [
   "'self'",
   "##VAR_analytics##",
-  "'sha256-aWZ3y/RxbBYKHXH0z8+8ljrHG1mSBvyzSfxSMjBSaXk='"
+  "'##VAR_scriptHashes##'"
 ]
+
 "style-src" = [
   "'self'",
   "'##VAR_styleHashes##'"

--- a/data/serverHeaders/static.toml
+++ b/data/serverHeaders/static.toml
@@ -1,0 +1,15 @@
+Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+X-Content-Type-Options = "nosniff"
+X-Frame-Options = "SAMEORIGIN"
+Referrer-Policy = "strict-origin"
+Permissions-Policy = [
+  "geolocation=(self)",
+  "microphone=()",
+  "camera=()"
+]
+Access-Control-Allow-Origin = "*"
+X-XSS-Protection = "1; mode=block"
+Cache-Control = [
+    "public",
+    "max-age=31536000"
+]

--- a/layouts/_partials/collect-headers.html
+++ b/layouts/_partials/collect-headers.html
@@ -1,0 +1,3 @@
+{{- $dynamicHeaders := partial "head/dynamic-headers.html" . }}
+{{- $headers := merge site.Data.serverHeaders.static $dynamicHeaders }}
+{{- return $headers -}}

--- a/layouts/_partials/collect-redirects.html
+++ b/layouts/_partials/collect-redirects.html
@@ -1,0 +1,62 @@
+{{- $ctx := . }}
+{{- $curPage := .Page }}
+{{- $redirects := dict }}
+{{- $domainRedirectValues := dict }}
+{{- with site.Data.serverRedirects.domains.redirectDomains }}
+  {{- range . }}
+    {{- $srcValue := printf "http://%s/*" . }}
+    {{- $redirValue := printf "%s://%s/:splat" (or site.Data.serverRedirects.domains.targetScheme "https")  site.Data.serverRedirects.domains.targetDomain }}
+    {{- $domainRedirectValues = merge $domainRedirectValues (dict
+      $srcValue $redirValue
+    ) }}
+  {{- end }}
+{{- end }}
+{{- if ne (or site.Data.serverRedirects.domains.targetScheme "https") "http" }}
+  {{- $srcValue := printf "http://%s/*" site.Data.serverRedirects.domains.targetDomain }}
+  {{- $redirValue := printf "%s://%s/:splat"  (or site.Data.serverRedirects.domains.targetScheme "https") site.Data.serverRedirects.domains.targetDomain }}
+  {{- $domainRedirectValues = merge $domainRedirectValues (dict
+    $srcValue $redirValue
+  ) }}
+{{- end }}
+{{- $hard301 := (dict "301!" $domainRedirectValues )}}
+{{- $redirects = merge $redirects $hard301 }}
+{{- $aliasRedirects := dict }}
+{{- with site.Pages }}
+  {{- range . }}
+    {{- if .Aliases }}
+      {{- $rTarget := .RelPermalink }}
+      {{- range .Aliases }}
+        {{- $srcValue := . }}
+        {{- $aliasRedirects = merge $aliasRedirects (dict
+          $srcValue $rTarget
+        ) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $hard301 := (dict "301!" $aliasRedirects )}}
+{{- $redirects = merge $redirects $hard301 }}
+{{- $regularRedirects := dict }}
+{{- $extraRedirects := dict }}
+{{- with (index site.Data.serverRedirects "path-status") }}
+  {{- $extraRedirects = merge $extraRedirects . }}
+{{- end }}
+{{- with site.Data.serverRedirects.wildcard }}
+  {{- $extraRedirects = merge $extraRedirects . }}
+{{- end }}
+{{- with $extraRedirects }}
+  {{- range $status, $redirects := . }}
+    {{- range $redirects }}
+      {{- $splitRedir := split . " " }}
+      {{- if eq (len $splitRedir) 2 }}
+        {{- $regularRedirects = merge $regularRedirects (dict
+        $status (dict (index $splitRedir 0) (index $splitRedir 1))
+        ) }}
+      {{- else }}
+        {{- errorf "Redirect '%s' invalid (wrong number of spaces)" . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $redirects = merge $redirects $regularRedirects }}
+{{- return $redirects -}}

--- a/layouts/_partials/footer/esbuild-hash.html
+++ b/layouts/_partials/footer/esbuild-hash.html
@@ -1,0 +1,81 @@
+{{- /* ESBUILD-HASH.HTML - Build javascript modules with esbuild
+  * Simple Usage: {{ partial "esbuild" "js/file.js" }}
+  * Simple Usage: {{ partial "esbuild" (dict "src" "js/file.js" "load" "defer/async" "babel" true ) }}
+  * Parameters:
+  * src - javascript file to build, relative to assets folder. Must include file extension can be .js or .ts
+  * load - can set to "defer" or "async" defaults to null.
+  * babel - set to true to transpile your js using babel. Note: all js is lowered to es6 by default.
+  * for babel you must have the required babel dependencies installed , and configured
+  * see hugo babel doc https://gohugo.io/hugo-pipes/babel
+  * use the babel option if esbuild can't handle lowering your es6+ code, or you wish to go lower than es6
+  * for unsupported es6+ syntax see
+  * https://esbuild.github.io/content-types/#javascript
+  *
+  * example for checking hugo env from js file
+  *
+  * import * as params from '@params';
+  *
+  * if (params.env === 'development') {
+  *   console.log('hugo deveolopment environment')
+  * } else {
+  *   console.log('hugo production environment')
+  * }
+  *
+  * ----------------------------------------------------------------*/ -}}
+{{- /* get source from . or .src and fetch resource */ -}}
+{{- $src := . -}}
+{{- if not $src -}}
+{{- errorf `You must provide a source as the partial context, or (dict .src "path")` -}}
+{{- end -}}
+{{- /* set .load only if valid option provided in dict */ -}}
+{{- $load := "" -}}
+{{- /* set .babel only if provided in dict */ -}}
+{{- $babel := false -}}
+{{- /* check for dict */ -}}
+{{- if reflect.IsMap . -}}
+{{- with .src -}}
+{{- $src = . -}}
+{{- else -}}
+{{- errorf "as you are providing params as a dict, you must provide the source file as .src" -}}
+{{- end -}}
+{{- with .load -}}
+{{- $loadOpts := slice "async" "defer" -}}
+{{- if not (in $loadOpts . ) -}}
+  {{- errorf "Invalid .load %q for file /assets/%s - valid options are %s." . $src (delimit $loadOpts ", " " and " ) -}}
+{{- end -}}
+{{- $load = . }}
+{{- end -}}
+{{- with .babel -}}
+{{- if eq . true -}}
+  {{- $babel = true -}}
+{{- else -}}
+  {{- errorf "Invalid .babel option of %q. The only valid option is true" . -}}
+{{- end -}}
+{{- end -}}
+{{ end }}
+{{- /* get the resource from .src path */ -}}
+{{- $resource := resources.Get $src -}}
+{{- /* if resources.Get fails */ -}}
+{{- if not $resource }}
+{{- errorf "No js resource found at /assets/%s" $src -}}
+{{- end -}}
+{{- /* pass hugo env to the js file as a param */ -}}
+{{- $params := (dict "env" hugo.Environment) -}}
+{{- /* standard production configuration for es build */ -}}
+{{- $jsConfig := (dict "target" "es2015" "minify" "true" "params" $params) }}
+{{- $js := $resource | js.Build $jsConfig | fingerprint -}}
+{{- /* is .babelEs6 is set to true - use babel to lower to es6 */ -}}
+{{- if $babel -}}
+{{- $babelConfig := (dict "noComments" true "minified" true "config" "config/babel.module.config.js") -}}
+{{- $js = $resource| js.Build $jsConfig | babel $babelConfig | fingerprint -}}
+{{- end -}}
+{{- if eq (hugo.Environment) "development" -}}
+{{- $jsConfig = (dict "sourceMap" "inline" "target" "es2015" "params" $params) -}}
+{{- $js = $resource | js.Build $jsConfig | fingerprint -}}
+{{- end -}}
+{{- return (dict
+  "src" $src
+  "js" $js
+  "load" $load
+  "hash" $js.Data.Integrity
+) -}}

--- a/layouts/_partials/footer/esbuild.html
+++ b/layouts/_partials/footer/esbuild.html
@@ -1,79 +1,10 @@
-{{- /* ESBUILD.HTML - Build javascript modules with esbuild
-  * Simple Usage: {{ partial "esbuild" "js/file.js" }}
-  * Simple Usage: {{ partial "esbuild" (dict "src" "js/file.js" "load" "defer/async" "babel" true ) }}
-  * Parameters:
-  * src - javascript file to build, relative to assets folder. Must include file extension can be .js or .ts
-  * load - can set to "defer" or "async" defaults to null.
-  * babel - set to true to transpile your js using babel. Note: all js is lowered to es6 by default.
-  * for babel you must have the required babel dependencies installed , and configured
-  * see hugo babel doc https://gohugo.io/hugo-pipes/babel
-  * use the babel option if esbuild can't handle lowering your es6+ code, or you wish to go lower than es6
-  * for unsupported es6+ syntax see
-  * https://esbuild.github.io/content-types/#javascript
-  *
-  * example for checking hugo env from js file
-  * 
-  * import * as params from '@params';
-  * 
-  * if (params.env === 'development') {
-  *   console.log('hugo deveolopment environment')
-  * } else {
-  *   console.log('hugo production environment')
-  * }
-  *
-  * ----------------------------------------------------------------*/ -}}
-{{- /* get source from . or .src and fetch resource */ -}}
-{{- $src := . -}}
-{{- if not $src -}}
-{{- errorf `You must provide a source as the partial context, or (dict .src "path")` -}}
-{{- end -}}
-{{- /* set .load only if valid option provided in dict */ -}}
-{{- $load := "" -}}
-{{- /* set .babel only if provided in dict */ -}}
-{{- $babel := false -}}
-{{- /* check for dict */ -}}
-{{- if reflect.IsMap . -}}
-{{- with .src -}}
-{{- $src = . -}}
-{{- else -}}
-{{- errorf "as you are providing params as a dict, you must provide the source file as .src" -}}
-{{- end -}}
-{{- with .load -}}
-{{- $loadOpts := slice "async" "defer" -}}
-{{- if not (in $loadOpts . ) -}}
-  {{- errorf "Invalid .load %q for file /assets/%s - valid options are %s." . $src (delimit $loadOpts ", " " and " ) -}}
-{{- end -}}
-{{- $load = . }}
-{{- end -}}
-{{- with .babel -}}
-{{- if eq . true -}}
-  {{- $babel = true -}}
-{{- else -}}
-  {{- errorf "Invalid .babel option of %q. The only valid option is true" . -}}
-{{- end -}}
-{{- end -}}
-{{ end }}
-{{- /* get the resource from .src path */ -}}
-{{- $resource := resources.Get $src -}}
-{{- /* if resources.Get fails */ -}}
-{{- if not $resource }}
-{{- errorf "No js resource found at /assets/%s" $src -}}
-{{- end -}}
-{{- /* pass hugo env to the js file as a param */ -}}
-{{- $params := (dict "env" hugo.Environment) -}}
-{{- /* standard production configuration for es build */ -}}
-{{- $jsConfig := (dict "target" "es2015" "minify" "true" "params" $params) }}
-{{- $js := $resource | js.Build $jsConfig | fingerprint -}}
-{{- /* is .babelEs6 is set to true - use babel to lower to es6 */ -}}
-{{- if $babel -}}
-{{- $babelConfig := (dict "noComments" true "minified" true "config" "config/babel.module.config.js") -}}
-{{- $js = $resource| js.Build $jsConfig | babel $babelConfig | fingerprint -}}
-{{- end -}}
-{{- if eq (hugo.Environment) "development" -}}
-{{- $jsConfig = (dict "sourceMap" "inline" "target" "es2015" "params" $params) -}}
-{{- $js = $resource | js.Build $jsConfig | fingerprint -}}
+{{- /* Call out to ESBILD-HASH.HTML to generate JS and calculate hash
+   * We do it this way so the hash can be available for adding to the
+   * Content-Security-Policy headers
+*/ -}}
+{{- $scriptHash := partial "footer/esbuild-hash.html" . }}
+{{- with $scriptHash }}
+<script {{ with $scriptHash.load }}{{ . | safeHTMLAttr }}{{ end }}
+src="{{- $scriptHash.js.RelPermalink -}}"
+integrity="{{- $scriptHash.js.Data.Integrity -}}"></script>
 {{ end -}}
-
-<script {{ with $load }}{{ . | safeHTMLAttr }}{{ end }} 
-src="{{- $js.RelPermalink -}}"
-integrity="{{- $js.Data.Integrity -}}"></script>

--- a/layouts/_partials/head/dynamic-headers.html
+++ b/layouts/_partials/head/dynamic-headers.html
@@ -1,0 +1,80 @@
+{{- $curPage := .Page }}
+{{- $headersDict := dict }}
+{{- range $header, $valueMap := site.Data.serverHeaders.dynamic }}
+  {{- $valueString := "" }}
+  {{- if not (reflect.IsMap $valueMap) }}
+    {{- errorf "Dynamic header '%s' is not a map in 'data'" $header }}
+  {{- end }}
+  {{- $delimiter := $valueMap.delimiter }}
+  {{- $subDelimiter := $valueMap.subDelimiter }}
+  {{- if reflect.IsMap $valueMap.subFields }}
+    {{- $fieldDelim := "" }}
+    {{- range $field, $value := $valueMap.subFields }}
+      {{- $subFieldNewValue := "" }}
+      {{- if reflect.IsSlice $value }}
+        {{- $subFieldNewValue = partial "buildSubField.html" (dict
+          "Page" $curPage
+          "subFieldName" $field
+          "subFieldOldValue" $subFieldNewValue
+          "subFieldNewValue" (index $value 0)
+          "valueDelim" ""
+        ) }}
+        {{- range after 1 $value }}
+          {{- $subFieldNewValue = partial "buildSubField.html" (dict
+            "Page" $curPage
+            "subFieldName" $field
+            "subFieldOldValue" $subFieldNewValue
+            "subFieldNewValue" .
+            "valueDelim" $subDelimiter
+          ) }}
+        {{- end }}
+      {{- else }}
+        {{- $subFieldNewValue = partial "buildSubField.html" (dict
+          "Page" $curPage
+          "subFieldName" $field
+          "subFieldNewValue" $value
+          "subFieldOldValue" ""
+          "valueDelim" ""
+        ) }}
+      {{- end }}
+      {{- if $subFieldNewValue }}
+        {{- $valueString = (add $valueString $fieldDelim $field " " $subFieldNewValue) }}
+      {{- end }}
+      {{- if not $fieldDelim }}
+        {{- $fieldDelim = $delimiter }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- errorf "Dynamic header '%s' missing subFields map" $header }}
+  {{- end }}
+  {{- $headersDict = merge $headersDict (dict $header $valueString) }}
+{{- end }}
+{{- return $headersDict -}}
+
+{{ define "_partials/buildSubField.html" }}
+  {{- $curPage := .Page }}
+  {{- $subField := .subFieldName }}
+  {{- $value := .subFieldNewValue }}
+  {{- $oldValue := .subFieldOldValue }}
+  {{- $valueDelim := .valueDelim }}
+  {{- $newValue := "" }}
+  {{- $customVar := findRESubmatch `^["']?##VAR_([0-9a-zA-Z-]+)##['"]?$` $value }}
+  {{- $customQuotes := findRESubmatch `^(["'])?##VAR_[0-9a-zA-Z-]+##['"]?$` $value }}
+  {{- if and $customVar (index (index $customVar 0) 1) }}
+    {{- $customVar = (index (index $customVar 0) 1) }}
+    {{- if templates.Exists (printf "_partials/head/header-custom-values/var-%s.html" $customVar) }}
+      {{- $customValue := partial (printf "head/header-custom-values/var-%s.html" $customVar) $curPage }}
+      {{- if reflect.IsSlice $customValue }}
+        {{- if and $customQuotes (index (index $customQuotes 0) 1) }}
+          {{- $customQuotes = index (index $customQuotes 0) 1 }}
+          {{- $customValue = add $customQuotes (delimit $customValue (add $customQuotes $valueDelim $customQuotes)) $customQuotes }}
+        {{- else }}
+          {{- $customValue = delimit $customValue $valueDelim }}
+        {{- end }}
+      {{- end }}
+      {{- $value = $customValue }}
+    {{- end }}
+  {{- end }}
+  {{- $newValue = (add $oldValue $valueDelim $value) }}
+  {{- return $newValue }}
+ {{ end }}

--- a/layouts/_partials/head/header-custom-values/var-analytics.html
+++ b/layouts/_partials/head/header-custom-values/var-analytics.html
@@ -1,0 +1,1 @@
+{{- with site.Params.analyticsUrl }}{{- . -}}{{- end -}}

--- a/layouts/_partials/head/header-custom-values/var-scriptHashes.html
+++ b/layouts/_partials/head/header-custom-values/var-scriptHashes.html
@@ -1,0 +1,7 @@
+{{- $scriptHashes := slice }}
+{{- $footerScriptHash := partial "footer/esbuild" (dict "src" "js/app.js" "targetPath" "main.js" "load" "async" "transpile" false) -}}
+{{- with $footerScriptHash }}
+  {{- with .hash }}
+    {{- $scriptHashes = $scriptHashes | append . }}
+  {{- end }}
+{{- end -}}

--- a/layouts/_partials/head/header-custom-values/var-styleHashes.html
+++ b/layouts/_partials/head/header-custom-values/var-styleHashes.html
@@ -1,0 +1,5 @@
+{{- $styleHashes := (union
+  ((partial "head/stylesheet-hashes.html" .).hashes)
+  ((partial "head/libsass-hash.html" "scss/app.scss").hashes)
+) -}}
+{{- return $styleHashes -}}

--- a/layouts/_partials/head/libsass-hash.html
+++ b/layouts/_partials/head/libsass-hash.html
@@ -1,0 +1,12 @@
+{{- $css := "" -}}
+{{- if eq (hugo.Environment) "development" -}}
+  {{- $options := (dict "targetPath" "main.css" "transpiler" "libsass" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
+  {{- $css = resources.Get . | toCSS $options | resources.Fingerprint "sha512" -}}
+{{- else -}}
+  {{- $options := (dict "targetPath" "main.css" "transpiler" "libsass" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
+  {{- $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | resources.Fingerprint "sha512" | resources.PostProcess -}}
+{{- end -}}
+{{- return (dict
+  "cssSrc" (slice $css)
+  "hashes" (slice $css.Data.Integrity)
+) -}}

--- a/layouts/_partials/head/libsass.html
+++ b/layouts/_partials/head/libsass.html
@@ -1,9 +1,0 @@
-{{ $css := "" }}
-{{ if eq (hugo.Environment) "development" -}}
-  {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
-  {{ $css = resources.Get . | toCSS $options | resources.Fingerprint "sha512" -}}
-{{ else -}}
-  {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
-  {{ $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") |  resources.Fingerprint "sha512" | resources.PostProcess -}}
-{{ end -}}
-<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">

--- a/layouts/_partials/head/stylesheet-hashes.html
+++ b/layouts/_partials/head/stylesheet-hashes.html
@@ -1,0 +1,10 @@
+{{- $cssStyleHashes := slice }}
+{{- $noscriptStyle := "img.lazyload { display:none; }" }}
+{{- $cssNoscriptCSS := resources.FromString "css/Noscript.css" $noscriptStyle }}
+{{- $cssNoscriptCSS = $cssNoscriptCSS | resources.Minify | resources.Fingerprint "sha512" }}
+{{- $cssStyleHashes = $cssStyleHashes | append (slice $cssNoscriptCSS.Data.Integrity) }}
+{{- return (dict
+  "cssNoScript" (slice $cssNoscriptCSS)
+  "hashes" $cssStyleHashes
+) }}
+{{- /* */ -}}

--- a/layouts/_partials/head/stylesheet.html
+++ b/layouts/_partials/head/stylesheet.html
@@ -1,2 +1,13 @@
-{{ partial "head/libsass" "scss/app.scss"}}
-<noscript><style>img.lazyload { display: none; }</style></noscript>
+{{ $cssDict := partial "head/libsass-hash.html" "scss/app.scss" }}
+{{- $styleDict := partial "head/stylesheet-hashes.html" . }}
+{{- $styleDict = merge $styleDict $cssDict }}
+{{- with $styleDict.cssNoScript }}
+  {{- range . }}
+<noscript><style>{{- .Content | safeCSS -}}</style></noscript>
+  {{- end }}
+{{- end }}
+{{- with $styleDict.cssSrc }}
+  {{- range . }}
+<link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+  {{- end }}
+{{- end }}

--- a/layouts/home.apache_htaccess
+++ b/layouts/home.apache_htaccess
@@ -1,0 +1,43 @@
+<IfModule mod_headers.c>
+{{- $headers := partial "collect-headers.html" . }}
+{{- range $header, $value := $headers }}
+  {{- if reflect.IsSlice $value }}
+Header setifempty {{ $header }} "{{- index $value 0 -}}"
+    {{- range after 1 $value }}
+Header append {{ $header }} "{{- . -}}"
+    {{- end }}
+  {{- else if $value }}
+Header setifempty {{ $header }} "{{- $value -}}"
+  {{- end }}
+{{- end }}
+</IfModule>
+
+ErrorDocument 404 /404.html
+
+<IfModule mod_rewrite.c>
+RewriteEngine On
+{{- $redirectMap := partial "collect-redirects.html" . }}
+{{- range $status, $redirects := $redirectMap }}
+  {{- if reflect.IsMap $redirects }}
+    {{- range $from, $to := $redirects }}
+      {{- $url := urls.Parse $from }}
+      {{- if $url.Scheme }}
+RewriteCond %{HTTP_HOST} ^{{ $url.Host }}$
+RewriteRule (.*) {{ site.BaseURL }}$1 [QSA,END,R=301]
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+RewriteCond %{HTTPS} off
+RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [QSA,END,R=301]
+{{- range $status, $redirects := $redirectMap }}
+  {{- if reflect.IsMap $redirects }}
+    {{- range $from, $to := $redirects }}
+      {{- $url := urls.Parse $from }}
+      {{- if not $url.Scheme }}
+Redirect {{ $status }} {{ $from }} {{ $to }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+</IfModule>

--- a/layouts/home.apache_htaccess
+++ b/layouts/home.apache_htaccess
@@ -36,6 +36,12 @@ RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [QSA,END,R=301]
     {{- range $from, $to := $redirects }}
       {{- $url := urls.Parse $from }}
       {{- if not $url.Scheme }}
+        {{- if hasSuffix $from "*" }}
+          {{- $from = printf "%s(.*)" (strings.TrimSuffix "*" $from) }}
+        {{- end }}
+        {{- if hasSuffix $to ":splat" }}
+          {{- $to = printf "%s$1" (strings.TrimSuffix ":splat" $to) }}
+        {{- end }}
 Redirect {{ $status }} {{ $from }} {{ $to }}
       {{- end }}
     {{- end }}

--- a/layouts/home.apache_htaccess
+++ b/layouts/home.apache_htaccess
@@ -16,12 +16,13 @@ ErrorDocument 404 /404.html
 
 <IfModule mod_rewrite.c>
 RewriteEngine On
+{{- $siteUrl := urls.Parse site.BaseURL }}
 {{- $redirectMap := partial "collect-redirects.html" . }}
 {{- range $status, $redirects := $redirectMap }}
   {{- if reflect.IsMap $redirects }}
     {{- range $from, $to := $redirects }}
       {{- $url := urls.Parse $from }}
-      {{- if $url.Scheme }}
+      {{- if and $url.Scheme (ne $siteUrl.Host $url.Host) }}
 RewriteCond %{HTTP_HOST} ^{{ $url.Host }}$
 RewriteRule (.*) {{ site.BaseURL }}$1 [QSA,END,R=301]
       {{- end }}

--- a/layouts/home.headers.json
+++ b/layouts/home.headers.json
@@ -1,0 +1,2 @@
+{{- $headers := partial "collect-headers.html" . -}}
+{{- jsonify $headers -}}

--- a/layouts/home.netlify_headers
+++ b/layouts/home.netlify_headers
@@ -1,0 +1,11 @@
+/*
+{{- $dynamicHeaders := partial "head/dynamic-headers.html" . }}
+{{- range $header, $value := (merge site.Data.serverHeaders.static $dynamicHeaders) }}
+  {{- if reflect.IsSlice $value }}
+    {{- range $value }}
+  {{ $header -}}: {{ . -}}
+    {{- end }}
+  {{- else if $value }}
+  {{ $header -}}: {{ $value -}}
+  {{- end }}
+{{- end }}

--- a/layouts/home.netlify_redirects
+++ b/layouts/home.netlify_redirects
@@ -1,0 +1,41 @@
+{{ $ctx := . }}
+{{ $curPage := .Page }}
+{{- with site.Data.serverRedirects.domains.redirectDomains }}
+  {{- range . }}
+http://{{- . -}}/* {{ or site.Data.serverRedirects.domains.targetScheme "https" -}}://{{- site.Data.serverRedirects.domains.targetDomain -}}/:splat 301!
+https://{{- . -}}/* {{ or site.Data.serverRedirects.domains.targetScheme "https" -}}://{{- site.Data.serverRedirects.domains.targetDomain -}}/:splat 301!
+  {{- end }}
+{{- end }}
+{{- if ne (or site.Data.serverRedirects.domains.targetScheme "https") "http" }}
+http://{{- site.Data.serverRedirects.domains.targetDomain -}}/* {{ or site.Data.serverRedirects.domains.targetScheme "https" -}}://{{- site.Data.serverRedirects.domains.targetDomain -}}/:splat 301!
+{{- end }}
+{{- with site.Pages }}
+  {{- range . }}
+    {{- if .Aliases }}
+      {{- $rTarget := .RelPermalink }}
+      {{- range .Aliases }}
+{{ . }} {{ $rTarget }} 301!
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- with (index site.Data.serverRedirects "path-status") }}
+  {{- range $status, $redirects := . }}
+    {{- range $redirects }}
+      {{- if ne (len (split . " " )) 2 }}
+        {{- errorf "Redirect '%s' invalid (wrong number of spaces)" . }}
+      {{- end }}
+{{ . }} {{ $status }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- with site.Data.serverRedirects.wildcard }}
+  {{- range $status, $redirects := . }}
+    {{- range $redirects }}
+      {{- if ne (len (split . " " )) 2 }}
+        {{- errorf "Redirect '%s' invalid (wrong number of spaces)" . }}
+      {{- end }}
+{{ . }} {{ $status }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/layouts/home.redirects.json
+++ b/layouts/home.redirects.json
@@ -1,0 +1,2 @@
+{{- $redirects := partial "collect-redirects.html" . -}}
+{{- jsonify $redirects -}}


### PR DESCRIPTION
## Summary

Generates JSON files with headers and redirects information. Optionally generates configuration for Apache 2.4 `.htaccess` and/or Netlify `_headers` and `_redirects`.
This enables setting the Content-Security-Policy with hashes for security. This will allow avoiding the uses of hard-coded nonces[1] and avoids the need to hard code the hashes whenever a script or style changes.

## Basic example

### Header configuration

1. Define the headers in `data/serverHeaders/static.toml` and `data/serverHeaders/dynamic/*.toml`
   `static.toml` might look like:

   ```toml
   Strict-Transport-Security = "max-age=31536000; includeSubDomains"
   X-Content-Type-Options = "nosniff"
   X-Frame-Options = "SAMEORIGIN"
   Referrer-Policy = "strict-origin"
   Permissions-Policy = [
     "geolocation=(self)",
     "microphone=()",
     "camera=()"
   ]
   Access-Control-Allow-Origin = "*"
   X-XSS-Protection = "1; mode=block"
   Cache-Control = [
     "public",
     "max-age=31536000"
   ]
   ```

2. a dynamic header might look like this one in `data/serverHeaders/dynamic/Content-Security-Policy.toml`

   ```toml
   "delimiter" = "; "
   "subDelimiter" = " "
      
   [subFields]
   "default-src" = "'self'"
   "manifest-src" = "'self'"
 
   "connect-src" = [
       "'self'",
       "##VAR_analytics##"
   ]
      
   "font-src" = ""
      
   "img-src" = [
      "'self'",
      "data:"
   ]
      
   "script-src" = [
     "'self'",
     "##VAR_analytics##",
     "'sha256-aWZ3y/RxbBYKHXH0z8+8ljrHG1mSBvyzSfxSMjBSaXk='"
   ]

   "style-src" = [
     "'self'",
     "'##VAR_styleHashes##'"
   ]
   ```

3. For the CSP above define the values for `##VAR_analytics##` and `##VAR_styleHashes##` by creating:
   1. `/layouts/_partials/header-custom-values/analytics.html` such as:

      ```go
      {{- with site.Params.analyticsUrl }}{{- . -}}{{- end -}}
      ```
  
   2. `/layouts/_partials/header-custom-values/styleHashes.html` such as:

      ```go
      {{- $styleHashes := (union
      ((partial "head/stylesheet-hashes.html" .).hashes)
      ((partial "head/libsass-hash.html" "scss/app.scss").hashes)
      ) -}}
      {{- return $styleHashes -}}          
      ```

4. Enable the header and redirect JSON generation in `hugo.toml`

   ```toml
   home = ["HTML", "RSS", "searchIndex", "htaccess", "headers", "redirects"]

   [outputFormats.headers]
   baseName = "headers"
   isPlainText = true
   mediaType = "application/json"
   notAlternative = true  

   [outputFormats.redirects]
   baseName = "redirects"
   isPlainText = true
   mediaType = "application/json"
   notAlternative = true  

   ```

5. (Optional) Enable Netlify and/or Apache 2.4 `.htaccess` configuration generation

   ```toml
   home = ["HTML", "RSS", "searchIndex", "apache_htaccess", "netlify_headers", "netlify_redirects"]

   [outputFormats.apache_htaccess]
   baseName = ""
   isPlainText = true
   mediaType = "text/htaccess"
   notAlternative = true
  
   [outputFormats.netlify_headers]
   baseName = "_headers"
   isPlainText = true
   mediaType = "text/netlify"
   notAlternative = true
  
   [outputFormats.netlify_redirects]
   baseName = "_redirects"
   isPlainText = true
   mediaType = "text/netlify"
   notAlternative = true
  
   [mediaTypes]
  
   [mediaTypes."text/htaccess"]
   suffixes = ["htaccess"]
  
   [mediaTypes."text/netlify"]
   delimiter = ""
   suffixes = [""]
   ```

6. Configure domain redirects

   ```toml
   redirectDomains = [
     "wildtechgarden.ca",
     "www.wildtechgarden.com",
     "wildtechgarden.com",
   ]
   targetDomain = "www.wildtechgarden.ca"
   targetScheme = "https"
   ```

   **NOTE** You do not include the main domain (the domain you want to be the baseURL: in this case `www.wildtechgarden.ca`) in `redirectDomains`.
  
7. Aliases are automatically turned into redirects.

8. Configure additional redirects. For example, in `/data/serverRedirects/path-status.toml`

   ```toml  
   301 = [
     "/feed /index.xml",
     "/post/feed /index.xml",
     "/develop-design/web-design-web-devel/test-theme-and-debug-tables/hugo-debug-tables-docs/ https://github.com/danielfdickinson/hugo-debug-tables",
     "/devel/hugo-debug-tables-docs/ https://github.com/danielfdickinson/hugo-debug-tables",
     "/projects/old-school/undergraduate/a-study-of-selected-algorithms-against-the-sherlock-and-zebra-problems/definitions-for-zebra-and-sherlock/ /doc/presentations/a-study-of-selected-algorithms-against-the-sherlock-and-zebra-problems/"

   ]
   ```

9. Finally, configure any regex redirects in `/data/serverRedirects/wildcard.toml` (using the same style of config as Netlify).

   ```toml
   301 = [
     "/post/* /blog/:splat",
     "/feed/* /index.xml",
     "/post/feed/* /index.xml"
   ]
   ```

## Motivation

1. Enable a proper Content-Security-Policy (and related headers). That is a CSP that with calculated hashes rather than hard-coded nonces and/or 'unsafe-inline' enabled.

2. Use proper header-based redirects instead of HTTP-REFRESH redirects.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [x] Supports both light and dark mode (if relevant) (not relevant)
- [ ] Passes `npm run test` (if relevant)

[1] <https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP#nonces>